### PR TITLE
refactor!(caste-client-ng): reworking http, prefering composition over inheritance

### DIFF
--- a/projects/caste-client-ng/src/lib/base.crud.service.ts
+++ b/projects/caste-client-ng/src/lib/base.crud.service.ts
@@ -6,15 +6,19 @@ import {
   CasteAuthConfig,
   DEFAULT_CONFIG,
 } from './caste-auth.config';
+import { CasteHttpClient } from './caste-http-client';
 
-export abstract class CasteCrudBase<T, R> extends BaseService {
-  public abstract endpoint: string;
+export abstract class CasteCrudBase<T, R> {
+  protected abstract endpoint: string;
+  private http: CasteHttpClient;
+  private opts: CasteAuthConfig = DEFAULT_CONFIG;
 
   constructor(
     @Inject(CASTE_AUTH_CONFIG) config: CasteAuthConfig,
     http: HttpClient
   ) {
-    super(http, { ...DEFAULT_CONFIG, ...config });
+    this.opts = config;
+    this.http = new CasteHttpClient(http, config);
   }
 
   protected getToken(): string {
@@ -22,22 +26,22 @@ export abstract class CasteCrudBase<T, R> extends BaseService {
   }
 
   public create(data: T) {
-    return this.post<R>(`/${this.endpoint}`, data);
+    return this.http.post<R>(`/${this.endpoint}`, data);
   }
 
   public listAll() {
-    return this.get<R[]>(`/${this.endpoint}`);
+    return this.http.get<R[]>(`/${this.endpoint}`);
   }
 
   public getOne(id: string) {
-    return this.get<R>(`/${this.endpoint}/${id}`);
+    return this.http.get<R>(`/${this.endpoint}/${id}`);
   }
 
   public update(id: string, data: T) {
-    return this.put<R>(`/${this.endpoint}/${id}`, data);
+    return this.http.put<R>(`/${this.endpoint}/${id}`, data);
   }
 
   public remove(id: string) {
-    return this.delete(`/${this.endpoint}/${id}`);
+    return this.http.delete(`/${this.endpoint}/${id}`);
   }
 }

--- a/projects/caste-client-ng/src/lib/management/caste-accounts.service.ts
+++ b/projects/caste-client-ng/src/lib/management/caste-accounts.service.ts
@@ -15,7 +15,7 @@ export class CasteAccountsService extends CasteCrudBase<
   Account,
   AccountResponse
 > {
-  public endpoint = 'accounts';
+  protected endpoint = 'accounts';
   constructor(
     @Inject(CASTE_AUTH_CONFIG) config: CasteAuthConfig,
     http: HttpClient

--- a/projects/caste-client-ng/src/lib/management/caste-applications.service.ts
+++ b/projects/caste-client-ng/src/lib/management/caste-applications.service.ts
@@ -16,7 +16,7 @@ export class CasteApplicationService extends CasteCrudBase<
   ApplicationData,
   ApplicationResponse
 > {
-  public endpoint = 'applications';
+  protected endpoint = 'applications';
   constructor(
     @Inject(CASTE_AUTH_CONFIG) config: CasteAuthConfig,
     http: HttpClient

--- a/projects/caste-client-ng/src/lib/management/caste-permissions.service.ts
+++ b/projects/caste-client-ng/src/lib/management/caste-permissions.service.ts
@@ -16,7 +16,7 @@ export class CastePermissionsService extends CasteCrudBase<
   Permission,
   PermissionResponse
 > {
-  public endpoint = 'permissions';
+  protected endpoint = 'permissions';
 
   constructor(
     @Inject(CASTE_AUTH_CONFIG) config: CasteAuthConfig,

--- a/projects/caste-client-ng/src/lib/management/caste-users.service.ts
+++ b/projects/caste-client-ng/src/lib/management/caste-users.service.ts
@@ -16,7 +16,7 @@ export class CasteUsersService extends CasteCrudBase<
   User,
   UserResponse
 > {
-  public endpoint = 'users';
+  protected endpoint = 'users';
   constructor(
     @Inject(CASTE_AUTH_CONFIG) config: CasteAuthConfig,
     http: HttpClient

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import {
-  QbitAuthService,
+  CasteAuthService,
+  CasteUsersService,
 } from 'projects/caste-client-ng/src/public-api';
 import { ApiError } from 'projects/caste-client-ng/src/lib/interfaces/api_error.interface';
 
@@ -13,9 +14,11 @@ export class AppComponent {
   title = 'qbit-ng-packages';
 
   constructor(
-    public qbitAuth: QbitAuthService,
+    public casteAuth: CasteAuthService,
+    public users: CasteUsersService
   ) {
     this.signIn();
+    // this.users.create();
     // this.handleResponse(this.qbitManagement.getApplicationsList());
     // this.handleResponse(
     //   this.qbitManagement.getApplicationById(
@@ -28,12 +31,12 @@ export class AppComponent {
     const token =
       'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE1OTY2MTc4NjQsImV4cCI6MTU5NjYyMTQ2NCwicm9sZXMiOlsiUk9MRV9VU0VSIl0sInVzZXJuYW1lIjoibWFub2xvIn0.nw2aZfT1MJ5S28HcaJTZx0YJQwsbqLFq0bckjmGn3hXSLhsIInPT6m2ZeFI1C4iE5Lkt1qtcdp-HGiCR4YDgcqFrAIRX7uB4kc0TfcvT6FweoWatrMyr5P9SdyfaRPjsxdBu98gaMhcHbQ3j2t27CsmHpbe3p5Zpm_gsi9urM0r0SifEcH-zedxNMuw6hazNvXAEA6Qzz97g4b-lzltYMFDKJXENQtzBcY2kNA-4o1VAS8z2EUgkK2KIsrph5aJICK9a8XTw5_Q7yaNL0Jf4k9Ky4is3vhdyDNiinQgHDy9QE1WGwt9Umz2-wXXjOOTtlX8dMdKcdcSxx53w4F-XOsi9CpDVr_JNc3wGDsNlRnsyCjEWVU5zB6fdJC10TFA7TWMrw8Ca2Xc5ki6tnFXZt24VdlQfEWUp5QVfsPE0GUMhH-uctqwl7gT7lD1X3Inhrq2-4r2O77o56D5CFWPFr90kdNhlJWvUXccBBSLpoWCAeTg6e8I00_EF0-v0E4dWFrRM_vjhGv17rW0fiP17PNIiryywtRAteBmbYtkbzR0pe7F4yBb41Hrs49ZBs5iy7y0CA4utSJbh8f08W4kOPIlrNZ9oEh05iAUCSAwRVWFbmv7RcOMGeQlzujYORtSi6aKz8w0x7kBj-0UFUhUUaQM82S2vchAEwbd_sGCsyfc';
 
-    const isValid = QbitAuthService.isTokenValid(token);
+    const isValid = CasteAuthService.isTokenValid(token);
     console.log({ isValid });
   }
 
   public signIn() {
-    const signInReq = this.qbitAuth.signIn({
+    const signInReq = this.casteAuth.signIn({
       username: 'manolo',
       password: 'test123',
       realm: 'default',
@@ -42,7 +45,7 @@ export class AppComponent {
   }
 
   public signUp() {
-    const signUpReq = this.qbitAuth.signUp({
+    const signUpReq = this.casteAuth.signUp({
       username: 'manolo',
       password: 'test123',
       realm: 'default',


### PR DESCRIPTION
Rethinking how to manage HTTP in a reusable manner. Previously extending from a base service, but that exposed to much implementation logic. Preferring an Http class instead.

Work in progress...